### PR TITLE
fix: windows compatibility because of near def in win header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@
 # Build folder
 build
 /.vs
-/out/install/x64-debug
+/out

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 
 # Build folder
 build
+/.vs
+/out/install/x64-debug

--- a/src/armadillo.cpp
+++ b/src/armadillo.cpp
@@ -9,8 +9,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
-
-
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 

--- a/src/asteroids.cpp
+++ b/src/asteroids.cpp
@@ -9,7 +9,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
-
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 

--- a/src/bunny.cpp
+++ b/src/bunny.cpp
@@ -9,8 +9,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
-
-
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 

--- a/src/crystal.cpp
+++ b/src/crystal.cpp
@@ -10,6 +10,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 

--- a/src/jet.cpp
+++ b/src/jet.cpp
@@ -9,8 +9,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
-
-
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 

--- a/src/singleTet.cpp
+++ b/src/singleTet.cpp
@@ -9,8 +9,7 @@ using namespace LavaCake;
 using namespace LavaCake::Geometry;
 using namespace LavaCake::Framework;
 #include <chrono>
-
-
+#undef near
 
 vec2d mousepos = vec2d({0,0});
 


### PR DESCRIPTION
The code currently does not compile with certain windows headers, because of a `near` define within one of the windows headers, which conflicts with the near float variable further down in the code file.

It also adds gitignore entries for easy use with MSVC